### PR TITLE
feat: Validate database file format

### DIFF
--- a/tap_msaccess/tap.py
+++ b/tap_msaccess/tap.py
@@ -23,7 +23,7 @@ class TapMSAccess(Tap):
     config_jsonschema = th.PropertiesList(
         th.Property(
             "database_file",
-            th.StringType,
+            th.StringType(pattern=r"\.(accdb)|(mdb)$"),
             required=True,
             description=(
                 "Local path or URL to a Microsoft Access database `.mdb` or `.accdb` "


### PR DESCRIPTION
Simple check for `database_file` config correctly references an `.accdb` or `.mdb` file.