### PR TITLE
ci: Azure tests failing to due to breaking change in `adlfs`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,7 +38,7 @@ jobs:
         - database-file: s3://tap-msaccess/Books.accdb
           connection-params: '{"anon": true}'
         - database-file: az://tap-msaccess/Books.accdb
-          connection-params: '{"account_name": "matatikaartifacts"}'
+          connection-params: '{"account_name": "matatikaartifacts","anon": true}'
     steps:
     - uses: actions/checkout@v6
     - name: Set up Python ${{ matrix.python-version }}


### PR DESCRIPTION
A breaking change in a new release of `adlfs` to not use anonymous access by default started causing the Azure tests to fail: https://github.com/fsspec/adlfs/releases/tag/2026.4.0