### PR TITLE
chore: add copyright notice to Python files

### DIFF
--- a/tap_msaccess/__init__.py
+++ b/tap_msaccess/__init__.py
@@ -1,1 +1,4 @@
-"""Tap for MSAccess."""
+"""Tap for MSAccess.
+
+Copyright (c) 2026 Meltano.
+"""

--- a/tap_msaccess/__main__.py
+++ b/tap_msaccess/__main__.py
@@ -1,4 +1,7 @@
-"""MSAccess entry point."""
+"""MSAccess entry point.
+
+Copyright (c) 2026 Meltano.
+"""
 
 from __future__ import annotations
 

--- a/tap_msaccess/_parser.py
+++ b/tap_msaccess/_parser.py
@@ -1,4 +1,7 @@
-"""MSAccess database file parser."""
+"""MSAccess database file parser.
+
+Copyright (c) 2026 Meltano.
+"""
 
 import access_parser.utils as access_parser_utils
 from access_parser import access_parser

--- a/tap_msaccess/client.py
+++ b/tap_msaccess/client.py
@@ -1,4 +1,7 @@
-"""Custom client handling, including MSAccessStream base class."""
+"""Custom client handling, including MSAccessStream base class.
+
+Copyright (c) 2026 Meltano.
+"""
 
 from __future__ import annotations
 

--- a/tap_msaccess/streams.py
+++ b/tap_msaccess/streams.py
@@ -1,1 +1,4 @@
-"""Stream type classes for tap-msaccess."""
+"""Stream type classes for tap-msaccess.
+
+Copyright (c) 2026 Meltano.
+"""

--- a/tap_msaccess/tap.py
+++ b/tap_msaccess/tap.py
@@ -1,4 +1,7 @@
-"""MSAccess tap class."""
+"""MSAccess tap class.
+
+Copyright (c) 2026 Meltano.
+"""
 
 from __future__ import annotations
 

--- a/tap_msaccess/utils.py
+++ b/tap_msaccess/utils.py
@@ -1,4 +1,7 @@
-"""tap-msaccess utilities."""
+"""tap-msaccess utilities.
+
+Copyright (c) 2026 Meltano.
+"""
 
 import re
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,4 +1,7 @@
-"""Test suite for tap-msaccess."""
+"""Test suite for tap-msaccess.
+
+Copyright (c) 2026 Meltano.
+"""
 
 from singer_sdk.testing.suites import TestSuite
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,4 +1,7 @@
-"""Tests standard tap features using the built-in SDK tests library."""
+"""Tests standard tap features using the built-in SDK tests library.
+
+Copyright (c) 2026 Meltano.
+"""
 
 from singer_sdk.testing import SuiteConfig, get_tap_test_class
 

--- a/tests/test_dynamic_discovery.py
+++ b/tests/test_dynamic_discovery.py
@@ -1,4 +1,7 @@
-"""Tests tap dynamic discovery."""
+"""Tests tap dynamic discovery.
+
+Copyright (c) 2026 Meltano.
+"""
 
 from itertools import zip_longest
 


### PR DESCRIPTION
The ruff update to `0.16.1` in #192 enforces the `CPY001` rule (missing copyright notice). Every Python file in the repository lacks a copyright notice, so ruff flags every file.

This change adds `Copyright (c) 2026 Meltano.` to the module docstring of each Python file. The `CPY001` check then passes.

The notice goes at the end of the existing module docstring, after a blank line:

```python
"""Stream type classes for tap-msaccess.

Copyright (c) 2026 Meltano.
"""
```

This format follows the notice that a maintainer added to tap-adp.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
