### PR TITLE
chore: automate copyright notices

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,6 +23,15 @@ repos:
   - id: check-dependabot
   - id: check-github-workflows
 
+- repo: https://github.com/Lucas-C/pre-commit-hooks
+  rev: v1.5.6
+  hooks:
+  - id: insert-license
+    files: \.py$
+    args:
+    - --license-filepath=license_header.txt
+    - --use-current-year
+
 - repo: https://github.com/astral-sh/ruff-pre-commit
   rev: v0.16.1
   hooks:

--- a/license_header.txt
+++ b/license_header.txt
@@ -1,0 +1,1 @@
+Copyright (c) 2026 Meltano.

--- a/tap_msaccess/__init__.py
+++ b/tap_msaccess/__init__.py
@@ -1,1 +1,3 @@
+# Copyright (c) 2026 Meltano.
+
 """Tap for MSAccess."""

--- a/tap_msaccess/__init__.py
+++ b/tap_msaccess/__init__.py
@@ -1,4 +1,1 @@
-"""Tap for MSAccess.
-
-Copyright (c) 2026 Meltano.
-"""
+"""Tap for MSAccess."""

--- a/tap_msaccess/__main__.py
+++ b/tap_msaccess/__main__.py
@@ -1,7 +1,4 @@
-"""MSAccess entry point.
-
-Copyright (c) 2026 Meltano.
-"""
+"""MSAccess entry point."""
 
 from __future__ import annotations
 

--- a/tap_msaccess/__main__.py
+++ b/tap_msaccess/__main__.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2026 Meltano.
+
 """MSAccess entry point."""
 
 from __future__ import annotations

--- a/tap_msaccess/_parser.py
+++ b/tap_msaccess/_parser.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2026 Meltano.
+
 """MSAccess database file parser."""
 
 import access_parser.utils as access_parser_utils

--- a/tap_msaccess/_parser.py
+++ b/tap_msaccess/_parser.py
@@ -1,7 +1,4 @@
-"""MSAccess database file parser.
-
-Copyright (c) 2026 Meltano.
-"""
+"""MSAccess database file parser."""
 
 import access_parser.utils as access_parser_utils
 from access_parser import access_parser

--- a/tap_msaccess/client.py
+++ b/tap_msaccess/client.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2026 Meltano.
+
 """Custom client handling, including MSAccessStream base class."""
 
 from __future__ import annotations

--- a/tap_msaccess/client.py
+++ b/tap_msaccess/client.py
@@ -1,7 +1,4 @@
-"""Custom client handling, including MSAccessStream base class.
-
-Copyright (c) 2026 Meltano.
-"""
+"""Custom client handling, including MSAccessStream base class."""
 
 from __future__ import annotations
 

--- a/tap_msaccess/streams.py
+++ b/tap_msaccess/streams.py
@@ -1,4 +1,1 @@
-"""Stream type classes for tap-msaccess.
-
-Copyright (c) 2026 Meltano.
-"""
+"""Stream type classes for tap-msaccess."""

--- a/tap_msaccess/streams.py
+++ b/tap_msaccess/streams.py
@@ -1,1 +1,3 @@
+# Copyright (c) 2026 Meltano.
+
 """Stream type classes for tap-msaccess."""

--- a/tap_msaccess/tap.py
+++ b/tap_msaccess/tap.py
@@ -1,7 +1,4 @@
-"""MSAccess tap class.
-
-Copyright (c) 2026 Meltano.
-"""
+"""MSAccess tap class."""
 
 from __future__ import annotations
 

--- a/tap_msaccess/tap.py
+++ b/tap_msaccess/tap.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2026 Meltano.
+
 """MSAccess tap class."""
 
 from __future__ import annotations

--- a/tap_msaccess/utils.py
+++ b/tap_msaccess/utils.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2026 Meltano.
+
 """tap-msaccess utilities."""
 
 import re

--- a/tap_msaccess/utils.py
+++ b/tap_msaccess/utils.py
@@ -1,7 +1,4 @@
-"""tap-msaccess utilities.
-
-Copyright (c) 2026 Meltano.
-"""
+"""tap-msaccess utilities."""
 
 import re
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2026 Meltano.
+
 """Test suite for tap-msaccess."""
 
 from singer_sdk.testing.suites import TestSuite

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,7 +1,4 @@
-"""Test suite for tap-msaccess.
-
-Copyright (c) 2026 Meltano.
-"""
+"""Test suite for tap-msaccess."""
 
 from singer_sdk.testing.suites import TestSuite
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,7 +1,4 @@
-"""Tests standard tap features using the built-in SDK tests library.
-
-Copyright (c) 2026 Meltano.
-"""
+"""Tests standard tap features using the built-in SDK tests library."""
 
 from singer_sdk.testing import SuiteConfig, get_tap_test_class
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2026 Meltano.
+
 """Tests standard tap features using the built-in SDK tests library."""
 
 from singer_sdk.testing import SuiteConfig, get_tap_test_class

--- a/tests/test_dynamic_discovery.py
+++ b/tests/test_dynamic_discovery.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2026 Meltano.
+
 """Tests tap dynamic discovery."""
 
 from itertools import zip_longest

--- a/tests/test_dynamic_discovery.py
+++ b/tests/test_dynamic_discovery.py
@@ -1,7 +1,4 @@
-"""Tests tap dynamic discovery.
-
-Copyright (c) 2026 Meltano.
-"""
+"""Tests tap dynamic discovery."""
 
 from itertools import zip_longest
 


### PR DESCRIPTION
#193 added a copyright notice to every Python file by hand. Each new file needs the same notice, and the year needs a manual bump. That is easy to forget and does not scale.

This change automates the notice with the Lucas-C `insert-license` hook. The hook inserts the notice into every Python file and keeps the year current with `--use-current-year`. It runs on pre-commit.ci, so the autofix stamps any file that lacks the notice and a contributor never edits the header by hand.

The notice becomes a comment above the module docstring in every `.py` file, including the tests:

```python
# Copyright (c) 2026 Meltano.

"""Stream type classes for tap-msaccess."""
```

## Notes

- The format differs from #193. The hook writes a comment header, not a notice inside the module docstring, because `insert-license` inserts comment blocks.
- `--use-current-year` converts a single year to a range when the year changes, for example `2026-2027`. A range still satisfies the ruff `CPY001` rule.
- The `files` pattern limits the hook to `.py` files, because it applies to all text files by default. The `--comment-style` option is omitted because `#` is the default.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
