### PR TITLE
chore: modernize the ruff pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,7 +36,6 @@ repos:
   rev: v0.16.1
   hooks:
   - id: ruff-check
-    exclude: tests/
   - id: ruff-format
 
 - repo: https://github.com/pre-commit/mirrors-mypy

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,8 +35,7 @@ repos:
 - repo: https://github.com/astral-sh/ruff-pre-commit
   rev: v0.16.1
   hooks:
-  - id: ruff
-    args: [--fix, --exit-non-zero-on-fix, --show-fixes]
+  - id: ruff-check
     exclude: tests/
   - id: ruff-format
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,11 @@ ignore = [
 ]
 select = ["ALL"]
 
+[tool.ruff.lint.per-file-ignores]
+"tests/**/*.py" = [
+    "S101",  # assert
+]
+
 [tool.ruff.lint.flake8-annotations]
 allow-star-arg-any = true
 

--- a/tests/test_dynamic_discovery.py
+++ b/tests/test_dynamic_discovery.py
@@ -9,9 +9,12 @@ from singer_sdk.testing.templates import TapTestTemplate
 
 
 class TapDynamicDiscoveryTest(TapTestTemplate):
+    """Test dynamic discovery of streams and their schemas."""
+
     name = "dynamic_discovery"
 
-    def test(self):
+    def test(self):  # noqa: PLR0915
+        """Assert each discovered stream in order, with its keys and schema."""
         streams = iter(self.tap.discover_streams())
         stream = next(streams, None)
 


### PR DESCRIPTION
The ruff pre-commit hook uses the deprecated `ruff` id, and ruff skips the test files. This change modernizes the hook and extends ruff to the test files, to align the configuration with the Meltano SDK template.

The hook now runs as `ruff-check` and `ruff-format` with no extra args. The `tests/` exclusion is removed, so ruff now lints the test files.

To keep the test files clean, this change ignores `S101` (`assert`) under `tests/**/*.py`. The SDK template applies the same ignore, but spells the rule `assert`. That name selector needs ruff preview mode, so this configuration uses the equivalent code `S101` instead.

`tests/test_dynamic_discovery.py` needs three small fixes for the remaining findings: a class docstring, a method docstring, and a targeted `PLR0915` waiver on the linear discovery test.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
